### PR TITLE
Various improvements & fixes in workspace scripts

### DIFF
--- a/build-all
+++ b/build-all
@@ -48,6 +48,10 @@ cat deps-order | while read package ; do {
             echo "Waiting for $COUNT builds ..."
         done
     else
+        if [[ $package == "-----" ]]; then
+            echo "Done!"
+            exit 0
+        fi
         if [[ $_FAILCOUNT -ge 1 ]]; then
             echo "Skipping $package"
             continue

--- a/deps-order
+++ b/deps-order
@@ -17,4 +17,4 @@ ledger
 contract-utils
 tx-utils
 -
--
+-----

--- a/forked-repos
+++ b/forked-repos
@@ -28,12 +28,14 @@ addRemote() {
         return
     }
 
+    GITHUB_AUTHZ="--header \"Authorization: Bearer $GITHUB_TOKEN\""
+    [[ -z $GITHUB_TOKEN ]] && {
+        GITHUB_AUTHZ=""
+    }
     echo "Checking for fork at https://api.github.com/repos/${USER_REPO_P}"
    FOUND=$(
-        curl --silent --fail-with-body \
-		--header "Authorization: Bearer $GITHUB_TOKEN" \
-		 "https://api.github.com/repos/${USER_REPO_P}" 
- 
+        curl --silent --fail-with-body $GITHUB_AUTHZ \
+		 "https://api.github.com/repos/${USER_REPO_P}"  
    )
     RESULT=$?
     # echo "RESULT: $RESULT"

--- a/functions.sh
+++ b/functions.sh
@@ -74,8 +74,36 @@ eachRepoUsage() {
 REPOS=""
 fetchRepoList() {
     [[ -z "$REPOS" ]] && {
-        REPOS=$(cat ./essentialRepos)
+    	[[ -f ./.heliosRepos ]] || {
+    	    echo "created ./.heliosRepos"
+            cp essentialRepos .heliosRepos
+        }
+        
+        [[ -f ./.heliosRepos ]] && {
+            REPOS=$(cat ./.heliosRepos)
+            return
+        } 
 
+        echo -n "  -- fetching Helios repo list ... "
+        OK=""
+        REPOS=$(
+        	curl --silent https://github.com/orgs/HeliosLang/repositories.json | 
+                jq -r '.payload.repositories[].name' |
+               # grep -ev "^cli$" |
+                sort
+        )
+        if [[ $? -ne 0 ]] ; then {
+            echo "failed!"
+            echo
+            echo "Error: failed fetching Helios repo list ... are you online?"
+        } else {
+            OK=1
+            echo "$REPOS" > ./.heliosRepos
+            echo "created ./.heliosRepos"
+            echo ok
+        } ; fi
+       [[ -z "$OK" ]] && exit 42
+    } >&2
 }
 
 eachRepo() {
@@ -126,12 +154,12 @@ eachRepo() {
             DIR="."
             LABEL="workspace:./"
         fi
-      [[ -d $DIR ]] || {
-        [[ -z $nocd ]] && { 
+
+      [[ ! -d $DIR && ! $nocd ]] && { 
          echo "skipping missing directory: $DIR" >&2
-        }         
-      }
-      [[ -d $DIR ]] || [[ -n $nocd ]] && {
+         continue
+      }        
+      {        
         TEMP=""
         [[ -z "$buffered" ]] || {
             TEMP=$(mktemp $TMPD/${REPO}.XXXXXX)
@@ -160,7 +188,12 @@ eachRepo() {
         [[ -z $parallel ]] && {
             # foreground; buffering is senseless
             [[ -z $nocd ]] && pushd $DIR >/dev/null
-             $func  2> >(labeledErrors $LABEL)
+            [[ $buffered ]] && {
+                $func  2> >(labeledErrors $LABEL)
+            }
+            [[ $buffered ]] || {
+                $func 
+            }
             [[ -z $nocd ]] && popd > /dev/null
          } 
         # [[ "compiler" == "${REPO}" ]] && {

--- a/setup.sh
+++ b/setup.sh
@@ -80,4 +80,10 @@ read -p"Next: $ " -e -i"pnpm install" COMMAND_IGNORED
 
 pnpm install
 
+echo "Next, build all packages (Ctrl-C to cancel)"
+echo
+read -p"Next: $ " -e -i"pnpm build:all" COMMAND_IGNORED
+
+pnpm build:all
+
 echo


### PR DESCRIPTION
 - fixed syntax problem (missing `}`)
 - don't skip missing directories when `nocd` is specified for eachRepo()
 - don't redirect stderr when "buffered" is not specified
   - ensures we show "clone this repo?" prompt during setup, when there is a fork found.
 - add "Next: build all" prompt at end of setup
 - use pre-packaged list of helios repos instead of using the full list of repos in the HeliosLang org
 - avoid reporting one error at end of build:all job
 - don't give Authorization header when there's no github token